### PR TITLE
Fix crash in case of empty LDAP response for CRL fetch

### DIFF
--- a/src/libstrongswan/plugins/ldap/ldap_fetcher.c
+++ b/src/libstrongswan/plugins/ldap/ldap_fetcher.c
@@ -93,8 +93,7 @@ static bool parse(LDAP *ldap, LDAPMessage *result, chunk_t *response)
 	}
 	else
 	{
-		DBG1(DBG_LIB, "finding first LDAP entry failed: %s",
-			 ldap_err2string(ldap_result2error(ldap, entry, 0)));
+		DBG1(DBG_LIB, "finding first LDAP entry failed");
 	}
 	return success;
 }


### PR DESCRIPTION
In case of empty LDAP result during CRL fetch (for example, due to wrong filter attribute in LDAP URI , or invalid LDAP configuration), call to ldap_result2error() with NULL value for "entry" lead to Strongswan crash.  
See assertion on http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=libraries/libldap/error.c;hb=HEAD#l256
